### PR TITLE
Dev/extended encodings

### DIFF
--- a/projects/client-api-react/src/index.js
+++ b/projects/client-api-react/src/index.js
@@ -31,10 +31,70 @@ const propTypes = {
 
     onClientAPIConnected: PropTypes.func,
 
+    pointColorEncoding:
+    		PropTypes.shape({
+		      attribute: PropTypes.string.isRequired,
+		      variation: PropTypes.string.isRequired,
+		      mapping: PropTypes.object
+		    }),
+    pointColorEncodingDefault:
+    		PropTypes.shape({
+		      attribute: PropTypes.string.isRequired,
+		      variation: PropTypes.string.isRequired,
+		      mapping: PropTypes.object
+		    }),    
+    pointSizeEncoding:
+    		PropTypes.shape({
+		      attribute: PropTypes.string.isRequired,
+		      mapping: PropTypes.object
+		    }),
+    pointSizeEncodingDefault:
+    		PropTypes.shape({
+		      attribute: PropTypes.string.isRequired,
+		      mapping: PropTypes.object
+		    }),
+    pointIconEncoding: 
+			PropTypes.shape({
+		      attribute: PropTypes.string.isRequired,
+		      mapping: PropTypes.object
+		    }),
+    pointIconEncodingDefault:
+		PropTypes.shape({
+		      attribute: PropTypes.string.isRequired,
+		      mapping: PropTypes.object
+		    }),
+    edgeColorEncoding:
+    		PropTypes.shape({
+		      attribute: PropTypes.string.isRequired,
+		      variation: PropTypes.string.isRequired,
+		      mapping: PropTypes.object
+		    }),    
+    edgeColorEncodingDefault:
+    		PropTypes.shape({
+		      attribute: PropTypes.string.isRequired,
+		      variation: PropTypes.string.isRequired,
+		      mapping: PropTypes.object
+		    }),    
+    //edgeSizeEncoding: PropTypes.object,
+    //edgeSizeEncodingDefault: PropTypes.object,
+    //edgeWeightEncoding: PropTypes.object,
+    //edgeWeightEncodingDefault: PropTypes.object,
+    edgeIconEncoding:
+			PropTypes.shape({
+		      attribute: PropTypes.string.isRequired,
+		      mapping: PropTypes.object
+		    }),    
+    edgeIconEncodingDefault:
+			PropTypes.shape({
+		      attribute: PropTypes.string.isRequired,
+		      mapping: PropTypes.object
+		    }),    
+    
+    nodes: PropTypes.arrayOf(),
+
     showInfo: PropTypes.bool,
     showMenu: PropTypes.bool,
     showLogo: PropTypes.bool,
-    showIcons: PropTypes.bool,
     showArrows: PropTypes.bool,
     showLabels: PropTypes.bool,
     showToolbar: PropTypes.bool,
@@ -59,7 +119,6 @@ const propTypes = {
     defaultPointSize: PropTypes.number,
     defaultEdgeOpacity: PropTypes.number,
     defaultPointOpacity: PropTypes.number,
-    defaultShowIcons: PropTypes.bool,
     defaultShowArrows: PropTypes.bool,
     defaultShowLabels: PropTypes.bool,
     defaultShowToolbar: PropTypes.bool,

--- a/projects/client-api-react/src/withClientAPI.js
+++ b/projects/client-api-react/src/withClientAPI.js
@@ -37,7 +37,7 @@ function applyPropsToClientAPI(iFrameRefHandler) {
             return Observable.of({ ...props, loading: !props.showSplashScreen, iFrameRefHandler });
         }
         const operations = [];
-        if (props.showIcons                                  ) operations.push(g.encodeIcons('point', 'pointIcon'));
+        
         if (typeof props.pointSize            !== 'undefined') operations.push(g.updateSetting('pointSize', props.pointSize));
         if (typeof props.edgeOpacity          !== 'undefined') operations.push(g.updateSetting('edgeOpacity', props.edgeOpacity));
         if (typeof props.pointOpacity         !== 'undefined') operations.push(g.updateSetting('pointOpacity', props.pointOpacity));
@@ -59,6 +59,46 @@ function applyPropsToClientAPI(iFrameRefHandler) {
         if (typeof props.gravity              !== 'undefined') operations.push(g.updateSetting('gravity', props.gravity));
         if (typeof props.scalingRatio         !== 'undefined') operations.push(g.updateSetting('scalingRatio', props.scalingRatio));
         if (typeof props.axes                 !== 'undefined') operations.push(g.encodeAxis(props.axes));
+
+        
+        ['point', 'edge'].forEach((graphType) => {       
+            ['', 'Default'].forEach((suffix) => {
+                const prop = props[`${graphType}IconEncoding${suffix}`];
+                if (typeof prop !== 'undefined') {
+                    const { attribute, mapping } = prop;                    
+                    operations.push(g[`encode${suffix}Icons`](graphType, attribute, mapping));
+                } else {
+                    operations.push(g[`encode${suffix}Icons`](graphType));
+                }
+            });
+        });
+        
+        ['point', 'edge'].forEach((graphType) => {       
+            ['', 'Default'].forEach((suffix) => {
+                const prop = props[`${graphType}SizeEncoding${suffix}`];
+                if (typeof prop !== 'undefined') {
+                    const { attribute, mapping } = prop;                    
+                    operations.push(g[`encode${suffix}Size`](graphType, attribute, mapping));
+                } else {
+                    operations.push(g[`encode${suffix}Size`](graphType));
+                }
+            });
+        });
+
+        ['point', 'edge'].forEach((graphType) => {       
+            ['', 'Default'].forEach((suffix) => {
+                const prop = props[`${graphType}ColorEncoding${suffix}`];
+                if (typeof prop !== 'undefined') {
+                    const { attribute, variation, mapping } = prop;                    
+                    operations.push(g[`encode${suffix}Color`](graphType, attribute, variation, mapping));
+                } else {
+                    operations.push(g[`encode${suffix}Color`](graphType));
+                }
+            });
+        });
+
+
+
         if (typeof props.workbook             !== 'undefined') operations.push(g.saveWorkbook());
         return Observable
             .merge(...operations)

--- a/projects/client-api/src/index.js
+++ b/projects/client-api/src/index.js
@@ -113,7 +113,7 @@ class Graphistry extends Observable {
      *     })
      *     .subscribe();
      */
-    static encodeColor(graphType, attribute, variation, colors) {
+    static encodeColor(graphType, attribute, variation, colors, mapping) {
         const { view } = this;
         return new this(view.set(
             $value(`encodings.${graphType}.color`,
@@ -200,6 +200,7 @@ class Graphistry extends Observable {
      * @method Graphistry.encodeIcons
      * @param {GraphType} [graphType] - 'point' or 'edge'
      * @param {Attribute} [attribute] - name of data column, e.g., 'icon'
+     * @param {Mapping} [object] - optional value mapping, e.g., {categorical: {fixed: {ip: 'laptop', alert: 'alaram'}, other: 'question'}}
      * @return {@link Graphistry} A {@link Graphistry} {@link Observable} that emits the result of the operation
      * @example
      *  GraphistryJS(document.getElementById('viz'))
@@ -209,12 +210,12 @@ class Graphistry extends Observable {
      *     })
      *     .subscribe();
      */
-    static encodeIcons(graphType, attribute) {
+    static encodeIcons(graphType, attribute, mapping) {
         const { view } = this;
         return new this(view.set(
             $value(`encodings.${graphType}.icon`,
                 {   reset: false, name: 'user_' + Math.random(),
-                    encodingType: 'icon', graphType, attribute }))
+                    encodingType: 'icon', graphType, attribute, mapping }))
             .map(({ json }) => json.toJSON())
             .toPromise());
     }
@@ -256,12 +257,12 @@ class Graphistry extends Observable {
      *     })
      *     .subscribe();
      */
-    static encodeSize(graphType, attribute) {
+    static encodeSize(graphType, attribute, mapping) {
         const { view } = this;
         return new this(view.set(
             $value(`encodings.${graphType}.size`,
                 {   reset: false, name: 'user_' + Math.random(),
-                    encodingType: 'size', graphType, attribute }))
+                    encodingType: 'size', graphType, attribute, mapping }))
             .map(({ json }) => json.toJSON())
             .toPromise());
     }

--- a/projects/client-api/src/index.js
+++ b/projects/client-api/src/index.js
@@ -338,6 +338,35 @@ class Graphistry extends Observable {
         }
     }
 
+    static encodeDefaultIcons(graphType, attribute, mapping) {
+        const { view } = this;
+        return new this(view.set(
+            $value(`encodings.defaults.${graphType}.icon`,
+                {   reset: false, name: 'user_' + Math.random(),
+                    encodingType: 'icon', graphType, attribute, mapping }))
+            .map(({ json }) => json.toJSON())
+            .toPromise());
+    }
+    static encodeDefaultSize(graphType, attribute, mapping) {
+        const { view } = this;
+        return new this(view.set(
+            $value(`encodings.defaults.${graphType}.size`,
+                {   reset: false, name: 'user_' + Math.random(),
+                    encodingType: 'size', graphType, attribute, mapping }))
+            .map(({ json }) => json.toJSON())
+            .toPromise());
+    }
+    static encodeDefaultColor(graphType, attribute, variation, colors, mapping) {
+        const { view } = this;
+        return new this(view.set(
+            $value(`encodings.defaults.${graphType}.color`,
+                {   reset: false, variation, name: 'user_' + Math.random(),
+                    encodingType: 'color', colors, graphType, attribute }))
+            .map(({ json }) => json.toJSON())
+            .toPromise());
+    }    
+
+
     /**
      * Toggle inspector panel
      * @method Graphistry.toggleInspector

--- a/projects/client-api/src/index.js
+++ b/projects/client-api/src/index.js
@@ -103,7 +103,7 @@ class Graphistry extends Observable {
      * @param {GraphType} [graphType] - 'point' or 'edge'
      * @param {Attribute} [attribute] - name of data column, e.g., 'degree'
      * @param {Variant} [variation] - If there are more bins than colors, use 'categorical' to repeat colors and 'continuous' to interpolate
-     * @param {Array} [colors] - array of color name or hex codes
+     * @param {Array} [mapping] - array of color name or hex codes
      * @return {@link Graphistry} A {@link Graphistry} {@link Observable} that emits the result of the operation
      * @example
      *  GraphistryJS(document.getElementById('viz'))
@@ -113,12 +113,12 @@ class Graphistry extends Observable {
      *     })
      *     .subscribe();
      */
-    static encodeColor(graphType, attribute, variation, colors, mapping) {
+    static encodeColor(graphType, attribute, variation, mapping) {
         const { view } = this;
         return new this(view.set(
             $value(`encodings.${graphType}.color`,
                 {   reset: false, variation, name: 'user_' + Math.random(),
-                    encodingType: 'color', colors, graphType, attribute }))
+                    encodingType: 'color', graphType, attribute, mapping }))
             .map(({ json }) => json.toJSON())
             .toPromise());
     }
@@ -356,12 +356,12 @@ class Graphistry extends Observable {
             .map(({ json }) => json.toJSON())
             .toPromise());
     }
-    static encodeDefaultColor(graphType, attribute, variation, colors, mapping) {
+    static encodeDefaultColor(graphType, attribute, variation, mapping) {
         const { view } = this;
         return new this(view.set(
             $value(`encodings.defaults.${graphType}.color`,
                 {   reset: false, variation, name: 'user_' + Math.random(),
-                    encodingType: 'color', colors, graphType, attribute }))
+                    encodingType: 'color', graphType, attribute, mapping }))
             .map(({ json }) => json.toJSON())
             .toPromise());
     }    

--- a/projects/client-api/src/index.js
+++ b/projects/client-api/src/index.js
@@ -98,7 +98,7 @@ class Graphistry extends Observable {
 
 
     /**
-     * Change colors based on an attribute
+     * Change colors based on an attribute. Pass null for attribute, mapping to clear.
      * @method Graphistry.encodeColor
      * @param {GraphType} [graphType] - 'point' or 'edge'
      * @param {Attribute} [attribute] - name of data column, e.g., 'degree'
@@ -117,34 +117,12 @@ class Graphistry extends Observable {
         const { view } = this;
         return new this(view.set(
             $value(`encodings.${graphType}.color`,
-                {   reset: false, variation, name: 'user_' + Math.random(),
+                {   reset: attribute === undefined, variation, name: 'user_' + Math.random(),
                     encodingType: 'color', graphType, attribute, mapping }))
             .map(({ json }) => json.toJSON())
             .toPromise());
     }
 
-    /**
-     * Reset color to value at page load
-     * @method Graphistry.resetColor
-     * @param {GraphType} [graphType] - 'point' or 'edge'
-     * @return {@link Graphistry} A {@link Graphistry} {@link Observable} that emits the result of the operation
-     * @example
-     *  GraphistryJS(document.getElementById('viz'))
-     *     .flatMap(function (g) {
-     *         window.g = g;
-     *         return g.encodeColor('point', 'degree', 'categorical', ['black', 'white'])
-     *         return g.resetColor('point')
-     *     })
-     *     .subscribe();
-     */
-    static resetColor(graphType) {
-        const { view } = this;
-        return new this(view.set(
-            $value(`encodings.${graphType}.color`,
-                {   reset: true, encodingType: 'color' }))
-            .map(({ json }) => json.toJSON())
-            .toPromise());
-    }
 
     /**
      * Change axis
@@ -164,39 +142,17 @@ class Graphistry extends Observable {
 
         return new this(view.set(
             $value(`encodings.point.axis`,
-                {   reset: false, name: 'user_' + Math.random(),
+                {   reset: axis === undefined, name: 'user_' + Math.random(),
                     encodingType: 'axis', graphType: 'point', attribute: 'degree', variation: 'categorical',
                     rows: axis }))
             .map(({ json }) => json.toJSON())
             .toPromise());
     }
 
-    /**
-     * Reset axis to value at page load
-     * @method Graphistry.resetAxis
-     * @return {@link Graphistry} A {@link Graphistry} {@link Observable} that emits the result of the operation
-     * @example
-     *  GraphistryJS(document.getElementById('viz'))
-     *     .flatMap(function (g) {
-     *         window.g = g;
-     *         return g.encodeAxis()
-     *         return g.resetAxis()
-     *     })
-     *     .subscribe();
-     */
-    static resetAxis() {
-        const { view } = this;
-        return new this(view.set(
-            $value(`encodings.point.axis`,
-                {   reset: true, encodingType: 'axis' }))
-            .map(({ json }) => json.toJSON())
-            .toPromise());
-    }
-
 
 
     /**
-     * Change icons based on an attribute
+     * Change icons based on an attribute. Pass undefined for attribute, mapping to clear.
      * @method Graphistry.encodeIcons
      * @param {GraphType} [graphType] - 'point' or 'edge'
      * @param {Attribute} [attribute] - name of data column, e.g., 'icon'
@@ -214,37 +170,16 @@ class Graphistry extends Observable {
         const { view } = this;
         return new this(view.set(
             $value(`encodings.${graphType}.icon`,
-                {   reset: false, name: 'user_' + Math.random(),
+                {   reset: attribute === undefined, name: 'user_' + Math.random(),
                     encodingType: 'icon', graphType, attribute, mapping }))
             .map(({ json }) => json.toJSON())
             .toPromise());
     }
 
-    /**
-     * Reset icons to value at page load
-     * @method Graphistry.resetIcons
-     * @param {GraphType} [graphType] - 'point' or 'edge'
-     * @return {@link Graphistry} A {@link Graphistry} {@link Observable} that emits the result of the operation
-     * @example
-     *  GraphistryJS(document.getElementById('viz'))
-     *     .flatMap(function (g) {
-     *         window.g = g;
-     *         return g.encodeIcons('point', 'icon')
-     *         return g.resetIcons('point')
-     *     })
-     *     .subscribe();
-     */
-    static resetIcons(graphType) {
-        const { view } = this;
-        return new this(view.set(
-            $value(`encodings.${graphType}.icon`,
-                {   reset: true, encodingType: 'icon' }))
-            .map(({ json }) => json.toJSON())
-            .toPromise());
-    }
+    
 
     /**
-     * Change size based on an attribute
+     * Change size based on an attribute. Pass null for attribute, mapping to clear.
      * @method Graphistry.encodeSize
      * @param {GraphType} [graphType] - 'point'
      * @param {Attribute} [attribute] - name of data column, e.g., 'degree'
@@ -261,35 +196,12 @@ class Graphistry extends Observable {
         const { view } = this;
         return new this(view.set(
             $value(`encodings.${graphType}.size`,
-                {   reset: false, name: 'user_' + Math.random(),
+                {   reset: attribute === undefined, name: 'user_' + Math.random(),
                     encodingType: 'size', graphType, attribute, mapping }))
             .map(({ json }) => json.toJSON())
             .toPromise());
     }
-
-
-    /**
-     * Reset size to value at page load
-     * @method Graphistry.resetSize
-     * @param {GraphType} [graphType] - 'point'
-     * @return {@link Graphistry} A {@link Graphistry} {@link Observable} that emits the result of the operation
-     * @example
-     *  GraphistryJS(document.getElementById('viz'))
-     *     .flatMap(function (g) {
-     *         window.g = g;
-     *         return g.encodeSize('point', 'community_infomap')
-     *         return g.resetSize('point')
-     *     })
-     *     .subscribe();
-     */
-    static resetSize(graphType) {
-        const { view } = this;
-        return new this(view.set(
-            $value(`encodings.${graphType}.size`,
-                {   reset: true, encodingType: 'size' }))
-            .map(({ json }) => json.toJSON())
-            .toPromise());
-    }
+    
 
     /**
      * Toggle a leftside panel
@@ -342,7 +254,7 @@ class Graphistry extends Observable {
         const { view } = this;
         return new this(view.set(
             $value(`encodings.defaults.${graphType}.icon`,
-                {   reset: false, name: 'user_' + Math.random(),
+                {   reset: attribute === undefined, name: 'user_' + Math.random(),
                     encodingType: 'icon', graphType, attribute, mapping }))
             .map(({ json }) => json.toJSON())
             .toPromise());
@@ -351,7 +263,7 @@ class Graphistry extends Observable {
         const { view } = this;
         return new this(view.set(
             $value(`encodings.defaults.${graphType}.size`,
-                {   reset: false, name: 'user_' + Math.random(),
+                {   reset: attribute === undefined, name: 'user_' + Math.random(),
                     encodingType: 'size', graphType, attribute, mapping }))
             .map(({ json }) => json.toJSON())
             .toPromise());
@@ -360,7 +272,7 @@ class Graphistry extends Observable {
         const { view } = this;
         return new this(view.set(
             $value(`encodings.defaults.${graphType}.color`,
-                {   reset: false, variation, name: 'user_' + Math.random(),
+                {   reset: attribute === undefined, variation, name: 'user_' + Math.random(),
                     encodingType: 'color', graphType, attribute, mapping }))
             .map(({ json }) => json.toJSON())
             .toPromise());


### PR DESCRIPTION
Pairs with https://github.com/graphistry/viz-app/pull/266 

![image](https://user-images.githubusercontent.com/4249447/31983837-e44ca906-b913-11e7-873f-c54bcd77aa0f.png)

Adds:
-- `mapping` parameter to encode(Size|Icon|Color)
-- `encodeDefault(Size|Icon|Color)`
-- React encoding props, including default encodings. When undefined, sends implicit `reset` (clear).

Renames:
-- `encodeColor(...colors...)` to `encodeColor(....mapping...)` Should be forwards compatible as long as vizapp interprets it.

Removes:
-- `reset(Axis|Size|Icon|Color)`