### PR TITLE
Dev/tolerate load errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,18 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## Development
+## 4.0.0-alpha.x
 
 ### Features
 
 * **React:** Upgraded to hooks (v17)
 * **React:** Unpinned, peer dependency, and optional externalization in binaries
 * **React:** Added new experimental props and callers
+* **tolerateLoadErrors:** React initial load continues even if some settings fail (default `true`)
 * **RxJS:** Upgraded (v7)
 * **RxJS:** Unpinned, peer dependency, and optional externalization in binaries
 * React now a required peer dependency when used from client-api-react
-* **Multiple format bundles**: `dist/index.{cjs,esm,iife}(.full?)(.min?).js`
+* **Multiple format bundles**: `dist/index.{cjs,esm,iife}(.full?)(.min?).js` . Use `full` for inlined `rxjs`, `react`, `react-dom`, otherwise must supply.
 
 ### Infra
 

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "4.0.0-alpha.4",
+  "version": "4.0.0-alpha.5",
   "packages": [
     "projects/client-api",
     "projects/client-api-react"

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "4.0.0-alpha.6",
+  "version": "4.0.0-alpha.7",
   "packages": [
     "projects/client-api",
     "projects/client-api-react"

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "4.0.0-alpha.5",
+  "version": "4.0.0-alpha.6",
   "packages": [
     "projects/client-api",
     "projects/client-api-react"

--- a/projects/client-api-react/package-lock.json
+++ b/projects/client-api-react/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/client-api-react",
-  "version": "4.0.0-alpha.4",
+  "version": "4.0.0-alpha.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/projects/client-api-react/package-lock.json
+++ b/projects/client-api-react/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/client-api-react",
-  "version": "4.0.0-alpha.6",
+  "version": "4.0.0-alpha.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/projects/client-api-react/package-lock.json
+++ b/projects/client-api-react/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/client-api-react",
-  "version": "4.0.0-alpha.5",
+  "version": "4.0.0-alpha.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/projects/client-api-react/package.json
+++ b/projects/client-api-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/client-api-react",
-  "version": "4.0.0-alpha.6",
+  "version": "4.0.0-alpha.7",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/graphistry/graphistry-js.git"
@@ -69,7 +69,7 @@
   "author": "Graphistry, Inc <https://graphistry.com>",
   "license": "ISC",
   "dependencies": {
-    "@graphistry/client-api": "^4.0.0-alpha.6",
+    "@graphistry/client-api": "^4.0.0-alpha.7",
     "prop-types": ">=15.6.0",
     "shallowequal": "1.1.0"
   },

--- a/projects/client-api-react/package.json
+++ b/projects/client-api-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/client-api-react",
-  "version": "4.0.0-alpha.4",
+  "version": "4.0.0-alpha.5",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/graphistry/graphistry-js.git"
@@ -69,7 +69,7 @@
   "author": "Graphistry, Inc <https://graphistry.com>",
   "license": "ISC",
   "dependencies": {
-    "@graphistry/client-api": "^4.0.0-alpha.4",
+    "@graphistry/client-api": "^4.0.0-alpha.5",
     "prop-types": ">=15.6.0",
     "shallowequal": "1.1.0"
   },

--- a/projects/client-api-react/package.json
+++ b/projects/client-api-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/client-api-react",
-  "version": "4.0.0-alpha.5",
+  "version": "4.0.0-alpha.6",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/graphistry/graphistry-js.git"
@@ -69,7 +69,7 @@
   "author": "Graphistry, Inc <https://graphistry.com>",
   "license": "ISC",
   "dependencies": {
-    "@graphistry/client-api": "^4.0.0-alpha.5",
+    "@graphistry/client-api": "^4.0.0-alpha.6",
     "prop-types": ">=15.6.0",
     "shallowequal": "1.1.0"
   },

--- a/projects/client-api-react/src/index.js
+++ b/projects/client-api-react/src/index.js
@@ -216,9 +216,9 @@ function propsToCommands({g, props, prevState, axesMap, tolerateLoadErrors}) {
                     !jsCommand ? updateSetting(jsName, val) : gAPI[jsCommand](val),
                     catchError(err => {
                         const msg = 'error running GraphistryJS command';
-                        console.error(msg, {g, err, name, jsName, jsCommand});
+                        console.error(msg, {g, err, name, jsName, jsCommand, tolerateLoadErrors});
                         if (tolerateLoadErrors) {
-                            return g.updateStateWithResult({msg, err});
+                            return of(g.updateStateWithResult({msg, err}));
                         }
                         throw err;
                     }));
@@ -323,7 +323,7 @@ function generateIframeRef({
                             }),
                             catchError(exn => {
                                 console.error('error in iframe initialization', exn);
-                                return g.updateStateWithResult(exn);
+                                return of(g.updateStateWithResult(exn));
                             }))),
                     tap((g) => {
                         console.debug('new iframe all init updates handled, if any', g);

--- a/projects/client-api-react/src/index.js
+++ b/projects/client-api-react/src/index.js
@@ -48,9 +48,6 @@ const propTypes = {
 
     showInfo: PropTypes.bool,
     showMenu: PropTypes.bool,
-    showToolbar: PropTypes.bool,
-    showInspector: PropTypes.bool,
-    showHistograms: PropTypes.bool,
     showSplashScreen: PropTypes.bool,
     loadingMessage: PropTypes.string,
 
@@ -99,8 +96,6 @@ const defaultProps = {
     showInfo: true,
     showMenu: true,
     showToolbar: true,
-    //showInspector: false,
-    //showHistograms: false,
     showSplashScreen: false,
     showLoadingIndicator: true,
     loadingMessage: 'Herding stray GPUs',

--- a/projects/client-api-react/src/index.js
+++ b/projects/client-api-react/src/index.js
@@ -175,18 +175,18 @@ const ETLUploader = (props) => {
                 }
             })
             .first()
-            .subscribe(
-                (response) => {
+            .subscribe({
+                next (response) {
                     setLoading(false);
                     setDataset(response.dataset);
                 },
-                (error) => {
+                error (error) {
                     setLoading(false);
                     setDataset(null);
                     setLoadingMessage('Error uploading graph');
                     console.error('error uploading graph', error);
                 }
-            );
+            });
 
         return () => {
             console.debug('unsubscribing upload', {url, payload, sub});
@@ -262,11 +262,10 @@ function handleUpdates({g, isFirstRun, axesMap, props}) {
         if (Object.keys(commands).length) {
             console.debug('dispatched all updating settings', commands);
             const sub = forkJoin(commands)
-                .subscribe(
-                    () => { },
-                    (e) => { console.error('iframe prop change error', e, commands); },
-                    () => { console.debug('iframe prop change done', commands); }
-                );
+                .subscribe({
+                    error (e) { console.error('iframe prop change error', e, commands); },
+                    complete () { console.debug('iframe prop change done', commands); }
+                });
             return () => {
                 sub.unsubscribe();
             }
@@ -335,10 +334,11 @@ function generateIframeRef({
                         }
                     }),
                 )
-                .subscribe(
-                    (v) => console.debug('iframe init sub hit', v),
-                    (e) => console.error('iframe init sub error', e),
-                    () => console.debug('iframe init sub complete'));
+                .subscribe({
+                    next (v) { console.debug('iframe init sub hit', v); },
+                    error (e) { console.error('iframe init sub error', e); },
+                    complete () { console.debug('iframe init sub complete'); }
+                });
             setGSub(sub);
             return () => {
                 // Not called in practice; maybe only if <Graphistry> itself is unmounted?

--- a/projects/client-api-react/src/index.js
+++ b/projects/client-api-react/src/index.js
@@ -216,7 +216,13 @@ function propsToCommands({g, props, prevState, axesMap}) {
                 }
 
             }
-            commands[name] = of(g).pipe(!jsCommand ? updateSetting(jsName, val) : gAPI[jsCommand](val));
+            commands[name] =
+                of(g).pipe(
+                    !jsCommand ? updateSetting(jsName, val) : gAPI[jsCommand](val),
+                    catchError(err => {
+                        console.error('error running GraphistryJS command', {g, err, name, jsName, jsCommand});
+                        throw err;
+                    }));
         }
     });
     if (props.axes && !axesMap.has(props.axes)) {

--- a/projects/client-api/package-lock.json
+++ b/projects/client-api/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/client-api",
-  "version": "4.0.0-alpha.4",
+  "version": "4.0.0-alpha.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/projects/client-api/package-lock.json
+++ b/projects/client-api/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/client-api",
-  "version": "4.0.0-alpha.6",
+  "version": "4.0.0-alpha.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/projects/client-api/package-lock.json
+++ b/projects/client-api/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/client-api",
-  "version": "4.0.0-alpha.5",
+  "version": "4.0.0-alpha.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/projects/client-api/package.json
+++ b/projects/client-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/client-api",
-  "version": "4.0.0-alpha.6",
+  "version": "4.0.0-alpha.7",
   "description": "Client-side API for interacting with a Graphistry embedded visualization.",
   "jsnext:main": "dist/index.js",
   "config": {

--- a/projects/client-api/package.json
+++ b/projects/client-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/client-api",
-  "version": "4.0.0-alpha.5",
+  "version": "4.0.0-alpha.6",
   "description": "Client-side API for interacting with a Graphistry embedded visualization.",
   "jsnext:main": "dist/index.js",
   "config": {

--- a/projects/client-api/package.json
+++ b/projects/client-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/client-api",
-  "version": "4.0.0-alpha.4",
+  "version": "4.0.0-alpha.5",
   "description": "Client-side API for interacting with a Graphistry embedded visualization.",
   "jsnext:main": "dist/index.js",
   "config": {

--- a/projects/client-api/src/index.js
+++ b/projects/client-api/src/index.js
@@ -186,7 +186,7 @@ const chainList = {};
                 console.debug('starting makeSetterWithModel postMessage cmds', values);
                 const sub = out.subscribe(
                     ((v) =>{ subscriber.next(v); }),
-                    ((e) =>{ subscriber.error('iframe setter fail', e); }),
+                    ((e) =>{ subscriber.error({msg: 'iframe setter fail', e}); }),
                     (() =>{ subscriber.complete(); }));
                 return () => {
                     console.debug('finished makeSetterWithModel; unsubscribe postMessage', {sub, values});

--- a/projects/client-api/src/index.js
+++ b/projects/client-api/src/index.js
@@ -186,7 +186,7 @@ const chainList = {};
                 console.debug('starting makeSetterWithModel postMessage cmds', values);
                 const sub = out.subscribe(
                     ((v) =>{ subscriber.next(v); }),
-                    ((e) =>{ subscriber.error({msg: 'iframe setter fail', e}); }),
+                    ((e) =>{ subscriber.error({msg: 'iframe setter fail', e, modelName, values}); }),
                     (() =>{ subscriber.complete(); }));
                 return () => {
                     console.debug('finished makeSetterWithModel; unsubscribe postMessage', {sub, values});


### PR DESCRIPTION
Motivated by showTimebar cmd failing and blocking rest of init sequence

React prop `tolerateLoadErrors` (default `true`) will tolerate individual errors, saving latest error in `g`, but letting overall `forkJoin(...commands...)` to succeed.