### PR TITLE
Dev/fix orgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+## 4.6.1
+
+### Added
+**js-upload-api**: Public helper `fetchToken()`
+
+### Fix
+**js-upload-api**: Upload config checks now pass when a token is used instead of creds
+
 ## 4.6.0
 
 ### Added

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "4.6.0",
+  "version": "4.6.1",
   "packages": [
     "projects/client-api",
     "projects/client-api-react",

--- a/projects/client-api-react/package-lock.json
+++ b/projects/client-api-react/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/client-api-react",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/projects/client-api-react/package.json
+++ b/projects/client-api-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/client-api-react",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/graphistry/graphistry-js.git"
@@ -69,7 +69,7 @@
   "author": "Graphistry, Inc <https://graphistry.com>",
   "license": "ISC",
   "dependencies": {
-    "@graphistry/client-api": "^4.6.0",
+    "@graphistry/client-api": "^4.6.1",
     "crypto-browserify": "3.12.0",
     "prop-types": ">=15.6.0",
     "shallowequal": "1.1.0",

--- a/projects/client-api/package-lock.json
+++ b/projects/client-api/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/client-api",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/projects/client-api/package.json
+++ b/projects/client-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/client-api",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "description": "Client-side API for interacting with a Graphistry embedded visualization.",
   "jsnext:main": "dist/index.js",
   "config": {
@@ -85,7 +85,7 @@
     "@graphistry/falcor-json-graph": "^2.9.10",
     "@graphistry/falcor-model-rxjs": "2.11.0",
     "@graphistry/falcor-socket-datasource": "2.11.3",
-    "@graphistry/js-upload-api": "^4.6.0",
+    "@graphistry/js-upload-api": "^4.6.1",
     "shallowequal": "1.1.0"
   },
   "peerDependencies": {

--- a/projects/cra-template/package-lock.json
+++ b/projects/cra-template/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/cra-template",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/projects/cra-template/package.json
+++ b/projects/cra-template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/cra-template",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "private": true,
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/projects/cra-test-18/package-lock.json
+++ b/projects/cra-test-18/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "test18",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/projects/cra-test-18/package.json
+++ b/projects/cra-test-18/package.json
@@ -1,9 +1,9 @@
 {
   "name": "test18",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "private": true,
   "dependencies": {
-    "@graphistry/client-api-react": "^4.6.0",
+    "@graphistry/client-api-react": "^4.6.1",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.2.0",
     "@testing-library/user-event": "^13.5.0",

--- a/projects/cra-test/package-lock.json
+++ b/projects/cra-test/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/client-react-app-cra-test",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/projects/cra-test/package.json
+++ b/projects/cra-test/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@graphistry/client-react-app-cra-test",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "private": true,
   "dependencies": {
     "@craco/craco": "^6.4.2",
-    "@graphistry/client-api-react": "^4.6.0",
+    "@graphistry/client-api-react": "^4.6.1",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^12.1.5",
     "@testing-library/user-event": "^14.2.0",

--- a/projects/js-upload-api/package-lock.json
+++ b/projects/js-upload-api/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/js-upload-api",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/projects/js-upload-api/package.json
+++ b/projects/js-upload-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/js-upload-api",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/graphistry/graphistry-js.git"

--- a/projects/js-upload-api/src/Client.ts
+++ b/projects/js-upload-api/src/Client.ts
@@ -234,15 +234,47 @@ export class Client {
         return tok;
     }
 
-    private authTokenValid(): boolean {
+    /**
+     * 
+     * @param username 
+     * @param password 
+     * @param org 
+     * @param protocol 
+     * @param host 
+     * @returns Promise for the authentication token
+     * 
+     * Helper to fetch a token for a given user
+     * 
+     */
+    public async fetchToken(
+        username: string, password: string, org?: string, protocol = 'https', host = 'hub.graphistry.com'
+    ): Promise<string> {
+        return (await this.postToApi(
+            'api/v2/auth/token/generate',
+            {
+                username: username,
+                password: password,
+                ...(org ? {org_name: org} : {}),
+            },
+            this.getBaseHeaders(),
+            `${protocol}://${host}/`
+        )).token;
+    }
+
+    /**
+     * 
+     * @returns Whether the current token is valid
+     * 
+     */
+    public authTokenValid(): boolean {
         const out = !!this._token;
         return out;
     }
 
-    private async postToApi(url: string, data: any, headers: any): Promise<any> {    // eslint-disable-line @typescript-eslint/no-explicit-any
+    private async postToApi(url: string, data: any, headers: any, baseUrl?: string): Promise<any> {    // eslint-disable-line @typescript-eslint/no-explicit-any
         const resolvedFetch = this.fetch;
         console.debug('postToApi', {url, data, headers});
-        const response = await resolvedFetch(this.getBaseUrl() + url, { // change this
+        const response = await resolvedFetch((baseUrl ?? this.getBaseUrl()) + url, { // change this
             method: 'POST',
             headers,
             body: 

--- a/projects/js-upload-api/src/Dataset.ts
+++ b/projects/js-upload-api/src/Dataset.ts
@@ -303,8 +303,8 @@ export class Dataset {
             throw new Error('No client provided');
         }
 
-        if (!client.isServerConfigured()) {
-            throw new Error('Client is not configured');
+        if (!client.authTokenValid() && !client.isServerConfigured()) {
+            throw new Error('Client is not configured, set token or creds');
         }
         console.debug('Uploading dataset', {nodeFiles: this.nodeFiles, edgeFiles: this.edgeFiles});
 

--- a/projects/js-upload-api/src/Privacy.ts
+++ b/projects/js-upload-api/src/Privacy.ts
@@ -149,8 +149,8 @@ export class Privacy {
         if (!client) {
             throw new Error('No client provided');
         }
-        if (!client.isServerConfigured()) {
-            throw new Error('Client is not configured');
+        if (!client.authTokenValid() && !client.isServerConfigured()) {
+            throw new Error('Client is not configured, set token or creds');
         }
 
         const opts = {

--- a/projects/node-api-test-cjs/package-lock.json
+++ b/projects/node-api-test-cjs/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/node-api-test",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/projects/node-api-test-cjs/package.json
+++ b/projects/node-api-test-cjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/node-api-test-cjs",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "description": "",
   "main": "src/index.js",
   "type": "commonjs",
@@ -16,7 +16,7 @@
   "author": "Graphistry, Inc.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@graphistry/node-api": "^4.6.0",
+    "@graphistry/node-api": "^4.6.1",
     "apache-arrow": "^11.0.0"
   }
 }

--- a/projects/node-api-test/package-lock.json
+++ b/projects/node-api-test/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/node-api-test",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/projects/node-api-test/package.json
+++ b/projects/node-api-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/node-api-test",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "description": "",
   "main": "src/index.js",
   "type": "module",
@@ -16,7 +16,7 @@
   "author": "Graphistry, Inc.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@graphistry/node-api": "^4.6.0",
+    "@graphistry/node-api": "^4.6.1",
     "apache-arrow": "^11.0.0"
   }
 }

--- a/projects/node-api/package-lock.json
+++ b/projects/node-api/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/node-api",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/projects/node-api/package.json
+++ b/projects/node-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/node-api",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/graphistry/graphistry-js.git"
@@ -74,7 +74,7 @@
     "typescript": "^4.6.4"
   },
   "dependencies": {
-    "@graphistry/js-upload-api": "^4.6.0",
+    "@graphistry/js-upload-api": "^4.6.1",
     "node-fetch-commonjs": "^3.2.4"
   }
 }


### PR DESCRIPTION
## 4.6.1

### Added
**js-upload-api**: Public helper `fetchToken()`

### Fix
**js-upload-api**: Upload config checks now pass when a token is used instead of creds

### Changed

Optional override of base path in `post()`