### PR TITLE
feat(toggleClustering)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## Dev
 
+### Added
+
+- **client-api**: `toggleClustering(isOn)` to start/stop clustering
+
 ### Infra
 
 - Update Storybook from 6 to 7
@@ -12,6 +16,10 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ### Security
 
 - Update dependencies
+
+### Fix
+
+- **client-api**: `tickClustering(milliseconds)` now works, requires Graphistry server upgrade
 
 ## 4.6.1
 

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "4.6.1",
+  "version": "5.0.0",
   "packages": [
     "projects/client-api",
     "projects/client-api-react",

--- a/projects/client-api-react/package-lock.json
+++ b/projects/client-api-react/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/client-api-react",
-  "version": "4.6.1",
+  "version": "5.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/projects/client-api-react/package.json
+++ b/projects/client-api-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/client-api-react",
-  "version": "4.6.1",
+  "version": "5.0.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/graphistry/graphistry-js.git"
@@ -69,7 +69,7 @@
   "author": "Graphistry, Inc <https://graphistry.com>",
   "license": "ISC",
   "dependencies": {
-    "@graphistry/client-api": "^4.6.1",
+    "@graphistry/client-api": "^5.0.0",
     "crypto-browserify": "3.12.0",
     "prop-types": ">=15.6.0",
     "shallowequal": "1.1.0",

--- a/projects/client-api/package-lock.json
+++ b/projects/client-api/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/client-api",
-  "version": "4.6.1",
+  "version": "5.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/projects/client-api/package.json
+++ b/projects/client-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/client-api",
-  "version": "4.6.1",
+  "version": "5.0.0",
   "description": "Client-side API for interacting with a Graphistry embedded visualization.",
   "jsnext:main": "dist/index.js",
   "config": {
@@ -85,7 +85,7 @@
     "@graphistry/falcor-json-graph": "^2.9.10",
     "@graphistry/falcor-model-rxjs": "2.11.0",
     "@graphistry/falcor-socket-datasource": "2.11.3",
-    "@graphistry/js-upload-api": "^4.6.1",
+    "@graphistry/js-upload-api": "^5.0.0",
     "shallowequal": "1.1.0"
   },
   "peerDependencies": {

--- a/projects/client-api/src/index.js
+++ b/projects/client-api/src/index.js
@@ -743,6 +743,15 @@ export function togglePanel(panel, turnOn) {
 }
 chainList.togglePanel = togglePanel;
 
+export function toggleClustering(selected) {
+    const values = [
+        $value(`scene.simulating`, selected),
+        $value(`scene.controls[0].selected`, selected)
+    ];
+    return makeSetter('view', ...values);
+}
+chainList.toggleClustering = toggleClustering;
+
 /**
  * @function encodeDefaultIcons
  * @description Change default (user-unset) icons based on an attribute. Pass undefined for attribute, mapping to clear.
@@ -995,8 +1004,8 @@ chainList.toggleHistograms = toggleHistograms;
 
 /**
  * @function Graphistry.tickClustering
- * @description Run a number of steps of Graphistry's clustering algorithm
- * @param {number} ticks - The number of ticks to run
+ * @description Run a number of milliseconds of Graphistry's clustering algorithm
+ * @param {number} ticks - The number of milliseconds to run
  * @return {@link GraphistryState} A {@link GraphistryState} {@link Observable} that emits the result of the operation
  * @example
  * GraphistryJS(document.getElementById('viz'))
@@ -1007,31 +1016,16 @@ chainList.toggleHistograms = toggleHistograms;
  *     .pipe(tickClustering(10))
  *     .subscribe();
  */
-export function tickClustering(/*ticks = 1*/) {
-
-    throw new Error('Not implemented');
-    /*
-
-    console.debug('tickClustering', {ticks});
-
+export function tickClustering(ticks = 1000) {
     if (typeof ticks !== 'number') {
         return map(g => g);
     }
-    return switchMap(g => {
-        return (
-            timer(0, 40)
-            .pipe(
-                tap((v) => console.debug('tick', v, g)),
-                take(Math.abs(ticks) || 1),
-                tap((v) => console.debug('tick b', v, g)),
-                map(() => g),
-                makeCaller('view', 'tick', [{}]),
-                isEmpty(),
-                tap((v) => console.debug('tick result', v, g)),
-                takeLast(1)
-            ));
-    });
-    */
+    return switchMap(g =>
+        of(g).pipe(
+            toggleClustering(true),
+            delay(ticks),
+            toggleClustering(false),
+            takeLast(1)));
 }
 chainList.tickClustering = tickClustering;
 
@@ -1308,7 +1302,7 @@ const G_API_SETTINGS = {
  * | `linLog` | `boolean` |
  * | `lockedX` | `boolean` | 
  * | `lockedY` | `boolean` | 
- * | `lockedR` | `boolean` | 
+ * | `lockedR` | `boolean` |
  * @function updateSetting
  * @param {string} name - the name of the setting to change
  * @param {string} val - the value to set the setting to.

--- a/projects/cra-template/package-lock.json
+++ b/projects/cra-template/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/cra-template",
-  "version": "4.6.1",
+  "version": "5.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/projects/cra-template/package.json
+++ b/projects/cra-template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/cra-template",
-  "version": "4.6.1",
+  "version": "5.0.0",
   "private": true,
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/projects/cra-test-18/package-lock.json
+++ b/projects/cra-test-18/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "test18",
-  "version": "4.6.1",
+  "version": "5.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/projects/cra-test-18/package.json
+++ b/projects/cra-test-18/package.json
@@ -1,9 +1,9 @@
 {
   "name": "test18",
-  "version": "4.6.1",
+  "version": "5.0.0",
   "private": true,
   "dependencies": {
-    "@graphistry/client-api-react": "^4.6.1",
+    "@graphistry/client-api-react": "^5.0.0",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.2.0",
     "@testing-library/user-event": "^13.5.0",

--- a/projects/cra-test/package-lock.json
+++ b/projects/cra-test/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/client-react-app-cra-test",
-  "version": "4.6.1",
+  "version": "5.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/projects/cra-test/package.json
+++ b/projects/cra-test/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@graphistry/client-react-app-cra-test",
-  "version": "4.6.1",
+  "version": "5.0.0",
   "private": true,
   "dependencies": {
     "@craco/craco": "^6.4.2",
-    "@graphistry/client-api-react": "^4.6.1",
+    "@graphistry/client-api-react": "^5.0.0",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^12.1.5",
     "@testing-library/user-event": "^14.2.0",

--- a/projects/js-upload-api/package-lock.json
+++ b/projects/js-upload-api/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/js-upload-api",
-  "version": "4.6.1",
+  "version": "5.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/projects/js-upload-api/package.json
+++ b/projects/js-upload-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/js-upload-api",
-  "version": "4.6.1",
+  "version": "5.0.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/graphistry/graphistry-js.git"

--- a/projects/node-api-test-cjs/package-lock.json
+++ b/projects/node-api-test-cjs/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/node-api-test",
-  "version": "4.6.1",
+  "version": "5.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/projects/node-api-test-cjs/package.json
+++ b/projects/node-api-test-cjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/node-api-test-cjs",
-  "version": "4.6.1",
+  "version": "5.0.0",
   "description": "",
   "main": "src/index.js",
   "type": "commonjs",
@@ -16,7 +16,7 @@
   "author": "Graphistry, Inc.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@graphistry/node-api": "^4.6.1",
+    "@graphistry/node-api": "^5.0.0",
     "apache-arrow": "^11.0.0"
   }
 }

--- a/projects/node-api-test/package-lock.json
+++ b/projects/node-api-test/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/node-api-test",
-  "version": "4.6.1",
+  "version": "5.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/projects/node-api-test/package.json
+++ b/projects/node-api-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/node-api-test",
-  "version": "4.6.1",
+  "version": "5.0.0",
   "description": "",
   "main": "src/index.js",
   "type": "module",
@@ -16,7 +16,7 @@
   "author": "Graphistry, Inc.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@graphistry/node-api": "^4.6.1",
+    "@graphistry/node-api": "^5.0.0",
     "apache-arrow": "^11.0.0"
   }
 }

--- a/projects/node-api/package-lock.json
+++ b/projects/node-api/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/node-api",
-  "version": "4.6.1",
+  "version": "5.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/projects/node-api/package.json
+++ b/projects/node-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/node-api",
-  "version": "4.6.1",
+  "version": "5.0.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/graphistry/graphistry-js.git"
@@ -74,7 +74,7 @@
     "typescript": "^4.6.4"
   },
   "dependencies": {
-    "@graphistry/js-upload-api": "^4.6.1",
+    "@graphistry/js-upload-api": "^5.0.0",
     "node-fetch-commonjs": "^3.2.4"
   }
 }


### PR DESCRIPTION
Stacks on https://github.com/graphistry/graphistry-js/pull/150

## Fix
`tickClustering(milliseconds)` - implement, really

## Add
`toggleClustering(isOn)`

---

These will require a corresponding Graphistry server upgrade that safelists the relevant client APi routes