### PR TITLE
Dev/fix localhost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## Dev
 
+## 5.0.1 - 2024-02-05
+
 ### Security
 
 - Disable Storybook telemetry
@@ -17,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 - Storybook: `@graphistry/client-api-react` dynamic clustering demo
 
-## 5.0.0 - 2023-02-02
+## 5.0.0 - 2024-02-02
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## Dev
 
+### Security
+
+- Disable Storybook telemetry
+
+
 ## 5.0.0 - 2023-02-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 - Disable Storybook telemetry
 
+### Fix
+
+- Storybook docs: Basepath determined by being Graphistry Github (=> Hub) else uses the serving basepath
 
 ## 5.0.0 - 2023-02-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 - Storybook docs: Basepath determined by being Graphistry Github (=> Hub) else uses the serving basepath
 
+### Docs
+
+- Storybook: `@graphistry/client-api-react` dynamic clustering demo
+
 ## 5.0.0 - 2023-02-02
 
 ### Added

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.0.0",
+  "version": "5.0.1",
   "packages": [
     "projects/client-api",
     "projects/client-api-react",

--- a/projects/client-api-react/package-lock.json
+++ b/projects/client-api-react/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/client-api-react",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/projects/client-api-react/package.json
+++ b/projects/client-api-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/client-api-react",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/graphistry/graphistry-js.git"
@@ -69,7 +69,7 @@
   "author": "Graphistry, Inc <https://graphistry.com>",
   "license": "ISC",
   "dependencies": {
-    "@graphistry/client-api": "^5.0.0",
+    "@graphistry/client-api": "^5.0.1",
     "crypto-browserify": "3.12.0",
     "prop-types": ">=15.6.0",
     "shallowequal": "1.1.0",

--- a/projects/client-api-react/package.json
+++ b/projects/client-api-react/package.json
@@ -58,7 +58,7 @@
     "prebuild:docs": "rimraf docs",
     "lint": "eslint src",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build -o docs-build -s ./assets"
+    "build-storybook": "storybook build --disable-telemetry -o docs-build -s ./assets"
   },
   "filesESBuild": [
     "dist",

--- a/projects/client-api-react/src/stories/Graphistry.stories.jsx
+++ b/projects/client-api-react/src/stories/Graphistry.stories.jsx
@@ -17,10 +17,15 @@ export const PredefinedDataset = {
   render: (args) => <Graphistry {...args} dataset="Miserables" showSplashScreen={true} />,
 };
 
+const hostname = window.location.hostname;
+const useHub = hostname === "github.com" || hostname === "graphistry.github.io";
+const graphistryHost = useHub ? 'https://hub.graphistry.com' : `${window.location.protocol}//${window.location.hostname}`;
+
 const defaultSettings = {
   dataset: 'Miserables',
   play: 1,
   showSplashScreen: true,
+  graphistryHost
 };
 
 export const NoSplashScreen = {

--- a/projects/client-api-react/src/stories/GraphistryJS.stories.jsx
+++ b/projects/client-api-react/src/stories/GraphistryJS.stories.jsx
@@ -36,8 +36,13 @@ import {
 } from '@graphistry/client-api';
 import { interval, takeWhile } from 'rxjs';
 
-//const basePath = 'https://hub.graphistry.com';
-const basePath = 'http://localhost';
+
+
+const hostname = window.location.hostname;
+const useHub = hostname === "github.com" || hostname === "graphistry.github.io";
+const basePath = useHub ? 'https://hub.graphistry.com' : `${window.location.protocol}//${window.location.hostname}`;
+
+//const basePath = 'http://localhost';
 const lesMisPath = `${basePath}/graph/graph.html?dataset=Miserables`;
 const lesMisConfigured = `${lesMisPath}&play=0`;
 const lesMisNoPlayNoSplash = `${lesMisPath}&play=0&splashAfter=false`;

--- a/projects/client-api/package-lock.json
+++ b/projects/client-api/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/client-api",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/projects/client-api/package.json
+++ b/projects/client-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/client-api",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Client-side API for interacting with a Graphistry embedded visualization.",
   "jsnext:main": "dist/index.js",
   "config": {
@@ -85,7 +85,7 @@
     "@graphistry/falcor-json-graph": "^2.9.10",
     "@graphistry/falcor-model-rxjs": "2.11.0",
     "@graphistry/falcor-socket-datasource": "2.11.3",
-    "@graphistry/js-upload-api": "^5.0.0",
+    "@graphistry/js-upload-api": "^5.0.1",
     "shallowequal": "1.1.0"
   },
   "peerDependencies": {

--- a/projects/cra-template/package-lock.json
+++ b/projects/cra-template/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/cra-template",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/projects/cra-template/package.json
+++ b/projects/cra-template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/cra-template",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "private": true,
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/projects/cra-test-18/package-lock.json
+++ b/projects/cra-test-18/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "test18",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/projects/cra-test-18/package.json
+++ b/projects/cra-test-18/package.json
@@ -1,9 +1,9 @@
 {
   "name": "test18",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "private": true,
   "dependencies": {
-    "@graphistry/client-api-react": "^5.0.0",
+    "@graphistry/client-api-react": "^5.0.1",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.2.0",
     "@testing-library/user-event": "^13.5.0",

--- a/projects/cra-test/package-lock.json
+++ b/projects/cra-test/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/client-react-app-cra-test",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/projects/cra-test/package.json
+++ b/projects/cra-test/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@graphistry/client-react-app-cra-test",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "private": true,
   "dependencies": {
     "@craco/craco": "^6.4.2",
-    "@graphistry/client-api-react": "^5.0.0",
+    "@graphistry/client-api-react": "^5.0.1",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^12.1.5",
     "@testing-library/user-event": "^14.2.0",

--- a/projects/js-upload-api/package-lock.json
+++ b/projects/js-upload-api/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/js-upload-api",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/projects/js-upload-api/package.json
+++ b/projects/js-upload-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/js-upload-api",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/graphistry/graphistry-js.git"

--- a/projects/node-api-test-cjs/package-lock.json
+++ b/projects/node-api-test-cjs/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/node-api-test",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/projects/node-api-test-cjs/package.json
+++ b/projects/node-api-test-cjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/node-api-test-cjs",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "",
   "main": "src/index.js",
   "type": "commonjs",
@@ -16,7 +16,7 @@
   "author": "Graphistry, Inc.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@graphistry/node-api": "^5.0.0",
+    "@graphistry/node-api": "^5.0.1",
     "apache-arrow": "^11.0.0"
   }
 }

--- a/projects/node-api-test/package-lock.json
+++ b/projects/node-api-test/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/node-api-test",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/projects/node-api-test/package.json
+++ b/projects/node-api-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/node-api-test",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "",
   "main": "src/index.js",
   "type": "module",
@@ -16,7 +16,7 @@
   "author": "Graphistry, Inc.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@graphistry/node-api": "^5.0.0",
+    "@graphistry/node-api": "^5.0.1",
     "apache-arrow": "^11.0.0"
   }
 }

--- a/projects/node-api/package-lock.json
+++ b/projects/node-api/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/node-api",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/projects/node-api/package.json
+++ b/projects/node-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphistry/node-api",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/graphistry/graphistry-js.git"
@@ -74,7 +74,7 @@
     "typescript": "^4.6.4"
   },
   "dependencies": {
-    "@graphistry/js-upload-api": "^5.0.0",
+    "@graphistry/js-upload-api": "^5.0.1",
     "node-fetch-commonjs": "^3.2.4"
   }
 }


### PR DESCRIPTION
Regression in 5.0.0 release Storybook docs was using `http://localhost` for the Graphistry server. Fixes that, + additional demo of new clustering API method

---

### Security

- Disable Storybook telemetry

### Fix

- Storybook docs: Basepath determined by being Graphistry Github (=> Hub) else uses the serving basepath

### Docs

- Storybook: `@graphistry/client-api-react` dynamic clustering demo