### PR TITLE
fix(storybook): passing &menu in url + clean up

### DIFF
--- a/projects/client-api-react/src/index.js
+++ b/projects/client-api-react/src/index.js
@@ -171,7 +171,6 @@ const ETLUploader = (props) => {
         setLoadingMessage('Uploading graph');
 
         const type = 'edgelist';
-        console.debug('we should not be here');
         const name = uuidv4();
         console.debug('clientapi react uuid4', { name });
         const payload = { type, name, graph: edges, labels: nodes, bindings };
@@ -564,6 +563,7 @@ const Graphistry = forwardRef((props, ref) => {
     const url = `${graphistryHost || ''}/graph/graph.html${''
         }?play=${playNormalized
         }&info=${showInfo
+        }&menu=${showMenu
         }&splashAfter=${showSplashScreen
         }&dataset=${encodeURIComponent(dataset)
         }${optionalParams}`;


### PR DESCRIPTION
There may be more to do, but showMenu now works verified via storybook

addresses[ this](https://github.com/orgs/graphistry/projects/94/views/1?pane=issue&itemId=109341152&issue=graphistry%7Cgraphistry%7C2695)
![Screenshot from 2025-05-08 14-58-34](https://github.com/user-attachments/assets/c56e1a4e-87fa-4fc1-8905-933fdb42b4fa)
